### PR TITLE
Fixed failure on programming2.R with gapminder extraction

### DIFF
--- a/functions/programming.functions.R
+++ b/functions/programming.functions.R
@@ -1,7 +1,7 @@
 # A function to return the mean value of the entries in the values.col from a
 #  data.frame, where the category.col is equal to category. 
 extract.mean.value <- function(data.frame, category, category.col, values.col) {
-  mean(data.frame[data.frame[,category.col]==category, values.col])
+  mean(data.frame[[values.col]][data.frame[,category.col]==category])
 } # extract.mean.value
 
 # A function to update a results.frame by overwriting it with a new version where


### PR DESCRIPTION
The programming2 example makes use of the "extract.mean.value" in
the utility file "programmin.functions".

The old code tried to compute the mean function on a single column
tibble (the new tidy format for gapminder) and it failed.